### PR TITLE
Fix s-qual regexp.

### DIFF
--- a/buildScripts/build-larsoft.sh
+++ b/buildScripts/build-larsoft.sh
@@ -51,7 +51,7 @@ labels=()
 for onequal in "${quals[@]}"; do
   if [[ "${onequal}" =~ ^([ec])([0-9]+)$ ]]; then
     basequal=${onequal}
-  elif [[ "${onequal}" =~ ^(s)([1-9][0-9]+)([a-z])$ ]]; then
+  elif [[ "${onequal}" =~ ^(s)([1-9][0-9]+)([a-z]*)$ ]]; then
     squal=${onequal}
   else
       labels+=${onequal}


### PR DESCRIPTION
Fix s-qual regexp in build-larsoft.sh.  Current regexp requires s-qual to have a final letter.